### PR TITLE
v 0.64-0.65 Manifiest 2.0, AJAX link support, left-click support

### DIFF
--- a/controller_actions.js
+++ b/controller_actions.js
@@ -287,15 +287,23 @@ function handleContentRequests(request, sender, sendResponse){
 	  new delugeConnection('', 'checkdaemonconnection', silent);
 	  
 	} */ else if (request.method.substring(0,8) == "addlink-" ) { //add to server request
+	  var url_match = false;
 	  var bits = request.method.split('-');
 	  var addtype = bits[1];
 	  var url = request['url'];
 	  var silent = request['silent'];
+	  
 	  if ( ! localStorage['server_url'] ) {
 			notify('Deluge Siphon', 'Please configure extension');
 			return;
 	  }
-	  if ( ! url && ( url.match(/^magnet\:/) || ! url.match(/^((file|(ht|f)tp(s?))\:\/\/).+/)) ) {
+	  if (!url) {
+			notify('Deluge Siphon', 'Error: Empty URL detected');
+			return;
+	  }
+
+	  url_match = url.match(/^(magnet\:)|((file|(ht|f)tp(s?))\:\/\/).+/) ;
+	  if (!url_match) {
 			notify('Deluge Siphon', 'Error: Invalid URL ['+url+']');
 			return;
 	  }


### PR DESCRIPTION
v 0.65 Added support for left-click handling (lawrencealan)
Fixed magnet link handling
Added support for regular click handling, with regular expression matching of HREF attributes

v 0.64 Upgrade to Manifiest 2.0, AJAX link support (lawrencealan)
Upgraded manifest.json and relative files to 2.0
Modified event listeners to use a single global "contextmenu" event listener on the window, so that sites that use AJAX updating to insert new links will work without having to re-scan the DOM for new anchor elements. This is also less work for the browser (versus scanning anchor elements) -- any contextmenu events will bubble up to this listener without having multiples.
