### PR TITLE
Update to use new Notification api

### DIFF
--- a/controller_actions.js
+++ b/controller_actions.js
@@ -363,21 +363,12 @@ function notify(message, decay, id, type) {
 		// notification.message = message;
 
 		// * we do this (to replace the notification).. 
-		notifications[id][0].cancel();
-		notification = webkitNotifications.createNotification(
-			chrome.extension.getURL(_icon),
-			title,
-			message
-			); 
-	} else {
-		// create a new notification  if we were sent no ID or if we're not tracking this hash
-		notification = webkitNotifications.createNotification(
-			chrome.extension.getURL(_icon),
-			title,
-			message
-		); 
+		notifications[id][0].close();
 	}
-	notification.show();
+	notification = new Notification(title, {
+		body: message,
+		icon: chrome.extension.getURL(_icon)
+	});
 	
 	var _timeout;
 	//negative decay means the user will have to close the window.
@@ -386,7 +377,7 @@ function notify(message, decay, id, type) {
 			clearTimeout(notifications[id][1]);
 			
 		_timeout = setTimeout(function(){ 
-			notification.cancel(); 
+			notification.close();
 			if (id != null)
 				delete notifications[id];
 		}, _decay);

--- a/manifest.json
+++ b/manifest.json
@@ -32,5 +32,15 @@
   }],
   "background": {
     "scripts": [ "utils.js", "controller_communicator.js", "controller_actions.js" ]
-  }
+  },
+  "web_accessible_resources": [
+    "images/login-16.png",
+    "images/login.png",
+    "images/notify.png",
+    "images/notify_added.png",
+    "images/notify_error.png",
+    "images/notify_request.png",
+    "images/options-16.png",
+    "images/options.png"
+  ]
 }


### PR DESCRIPTION
The old webkitNotifications.createNotification() API was removed in Chrome 35. This pull request fixes #10 by changing to use the new standard Notification API. It also explicitly lists the images used in the notifications in the 'web_accessible_resources' field of the manifest to allow them to be properly displayed.
